### PR TITLE
feat: allow optional HTTPS for git origin

### DIFF
--- a/common/generate-config.js
+++ b/common/generate-config.js
@@ -16,6 +16,13 @@ if (process.platform === 'win32') {
   envVars.GYP_MSVS_VERSION = '2017';
 }
 
+envVars.ELECTRON_GIT_ORIGIN = 'git@github.com:electron/electron.git';
+envVars.NODE_GIT_ORIGIN = 'git@github.com:electron/node.git';
+if (config.gitUseHttps) {
+  envVars.NODE_GIT_ORIGIN = 'https://github.com/electron/node';
+  envVars.ELECTRON_GIT_ORIGIN = 'https://github.com/electron/electron';
+}
+
 envVars.CHROMIUM_BUILDTOOLS_PATH = path.resolve(envVars.ELECTRON_GN_ROOT, 'src', 'buildtools');
 
 envVars.SCCACHE_TWO_TIER = 'true';

--- a/config.example.yml
+++ b/config.example.yml
@@ -12,5 +12,8 @@ gitCachePath: .git-cache
 # (Optional): The name of the build config to use, default is "debug".  Possible values are debug, testing and release
 # buildType: debug
 
+# (Optional): Whether or not git should use HTTPS or SSH; uses SSH by default
+# gitUseHttps: true
+
 # (Optional): Any extra arguments to pass to GN, useful for setting up a MAS build
 # extraGnArgs:

--- a/nix/commands/sync.sh
+++ b/nix/commands/sync.sh
@@ -14,11 +14,11 @@ gclient sync --with_branch_heads --with_tags "$@"
 echo Updating Git Remotes
 
 cd $ELECTRON_GN_ROOT/src/electron
-git remote set-url origin git@github.com:electron/electron.git
-git remote set-url origin --push git@github.com:electron/electron.git
+git remote set-url origin $ELECTRON_GIT_ORIGIN
+git remote set-url origin --push $ELECTRON_GIT_ORIGIN
 
 cd $ELECTRON_GN_ROOT/src/third_party/electron_node
-git remote set-url origin git@github.com:electron/node.git
-git remote set-url origin --push git@github.com:electron/node.git
+git remote set-url origin $NODE_GIT_ORIGIN
+git remote set-url origin --push $NODE_GIT_ORIGIN
 
 echo Done Syncing

--- a/win/commands/sync.bat
+++ b/win/commands/sync.bat
@@ -13,17 +13,17 @@ if %errorlevel%=="1" goto :fail
 echo Updating git remotes
 
 cd electron
-call git remote set-url origin git@github.com:electron/electron.git
+call git remote set-url origin %ELECTRON_GIT_ORIGIN%
 if %errorlevel%=="1" goto :fail
 
-call git remote set-url origin --push git@github.com:electron/electron.git
+call git remote set-url origin --push %ELECTRON_GIT_ORIGIN%
 if %errorlevel%=="1" goto :fail
 
 cd ..\third_party\electron_node
-call git remote set-url origin git@github.com:electron/node.git
+call git remote set-url origin %NODE_GIT_ORIGIN%
 if %errorlevel%=="1" goto :fail
 
-call git remote set-url origin --push git@github.com:electron/node.git
+call git remote set-url origin --push %NODE_GIT_ORIGIN%
 if %errorlevel%=="1" goto :fail
 
 exit /B 0


### PR DESCRIPTION
Allows using HTTPS instead of SSH when resetting Electron's & Node's origins.

cc @MarshallOfSound 