### PR TITLE
fix: anonymous functions don't get hoisted

### DIFF
--- a/common/validate-env.js
+++ b/common/validate-env.js
@@ -1,7 +1,11 @@
 const chalk = require('chalk').default;
 const fs = require('fs');
-const path = require('path');
 const yaml = require('yaml-js');
+
+const fail = (message) => {
+  console.error(chalk.red(message));
+  process.exit(1);
+};
 
 const { configPath, resolveConfiguredPath } = require('./util');
 
@@ -23,11 +27,6 @@ if (!fs.existsSync(configPath)) {
 }
 
 const config = yaml.load(fs.readFileSync(configPath))
-
-const fail = (message) => {
-  console.error(chalk.red(message));
-  process.exit(1);
-};
 
 for (const prop of REQUIRED_CONFIG_PROPERTIES) {
   const value = config[prop.name];


### PR DESCRIPTION
This was failing on:

```sh
electron-gn-scripts on git:master ❯ e generate-config                          7:53PM
/Users/codebytere/electron-gn-scripts/common/validate-env.js:22
  fail('You must create a config.yml file in the root of this repository, copy config.example.yml to get started');
  ^

ReferenceError: Cannot access 'fail' before initialization
    at Object.<anonymous> (/Users/codebytere/electron-gn-scripts/common/validate-env.js:22:3)
.... rest of stacktrace
```