### PR TITLE
feat: add debug command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,25 @@ e test
 e test --ci
 ```
 
+### `e debug`
+
+Initializes [lldb](https://lldb.llvm.org/) (on macOS) or [gdb](https://www.gnu.org/software/gdb/) (on Linux) with the debug target set to your local Electron build.
+
+```bash
+e debug
+
+# You should then see (on macOS, for example):
+# (lldb) target create "/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/MacOS/Electron"
+#Current executable set to '/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/MacOS/Electron' (x86_64).
+# (lldb) < you can now run debug commands here>
+```
+
+Debugging Resources:
+* `lldb` [Tutorial](https://lldb.llvm.org/use/tutorial.html)
+* `gdb` [Tutorial](https://web.eecs.umich.edu/~sugih/pointers/summary.html)
+
+**Nota Bene:** This works on macOS and Linux only.
+
 ## Multiple Configs
 
 If you're doing a lot of Electron development and constantly switching targets or branches it is a good idea to

--- a/nix/commands/debug.sh
+++ b/nix/commands/debug.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+source $basedir/__load-config.sh
+
+if [ "$(uname)" == "Darwin" ]; then
+  lldb "$ELECTRON_GN_ROOT/src/out/$ELECTRON_OUT_DIR/Electron.app/Contents/MacOS/Electron"
+else
+  gdb "$ELECTRON_GN_ROOT/src/out/$ELECTRON_OUT_DIR/electron"
+fi

--- a/nix/e
+++ b/nix/e
@@ -10,7 +10,7 @@ args="${@:2}"
 # Functions
 missing_command() {
   echo Usage: e [command] [...args]
-  echo You must provide a valid command, must be one of 'generate-config', 'sync', 'bootstrap', 'build', 'start', 'test' or 'pr'
+  echo You must provide a valid command, must be one of 'generate-config', 'sync', 'bootstrap', 'build', 'start', 'test', 'testnode', 'debug' or 'pr'
   exit 1
 }
 


### PR DESCRIPTION
Adds a new cross-platform command for native debugging with lldb/gdb: `e debug`.

cc @MarshallOfSound 