### PR TITLE
feat: add command for patch exporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ Debugging Resources:
 
 **Nota Bene:** This works on macOS and Linux only.
 
+### `e export-patches [patch-dir]`
+
+Exports patches to the desired patch folder in Electron source tree.
+
+Valid patch directories include:
+* `node`
+* `v8`
+* `boringssl`
+* `chromium`
+
+**Nota Bene:** You need to be running at least Bash v4 to use this command.
+
 ## Multiple Configs
 
 If you're doing a lot of Electron development and constantly switching targets or branches it is a good idea to

--- a/nix/commands/export-patches.sh
+++ b/nix/commands/export-patches.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+source $basedir/__load-config.sh
+
+# wrapper fn to check if a key exists in a hashmap
+function array_key_exists() {
+  local _array_name="$1"
+  local _key="$2"
+  local _cmd='echo ${!'$_array_name'[@]}'
+  local _array_keys=($(eval $_cmd))
+  local _key_exists=$(echo " ${_array_keys[@]} " | grep " $_key " &>/dev/null; echo $?)
+  [[ "$_key_exists" = "0" ]] && return 0 || return 1
+}
+
+# init hashmap of valid patch directories
+declare -A patch_dirs
+patch_dirs["node"]="third_party/electron_node"
+patch_dirs["v8"]="v8"
+patch_dirs["chromium"]=""
+patch_dirs["boringssl"]="third_party/boringssl"
+
+SRC_DIR=$ELECTRON_GN_ROOT/src
+
+if [[ "$(array_key_exists 'patch_dirs' "$1"; echo $?)" = "0" ]]; then
+  cd $SRC_DIR/${patch_dirs[$@]}
+  $SRC_DIR/electron/script/git-export-patches -o $SRC_DIR/electron/patches/"$1"
+else
+  echo "Error: invalid patch directory passed."
+fi

--- a/nix/e
+++ b/nix/e
@@ -10,7 +10,7 @@ args="${@:2}"
 # Functions
 missing_command() {
   echo Usage: e [command] [...args]
-  echo You must provide a valid command, must be one of 'generate-config', 'sync', 'bootstrap', 'build', 'start', 'test', 'testnode', 'debug' or 'pr'
+  echo You must provide a valid command, must be one of 'generate-config', 'sync', 'bootstrap', 'build', 'start', 'test', 'testnode', 'debug', 'export-patches' or 'pr'
   exit 1
 }
 


### PR DESCRIPTION
Adds a new command `e export-patches [dir]` to export patches to the desired patch folder in Electron source tree.

cc @MarshallOfSound 