### PR TITLE
feat: on nix, automate depot-tools installation and 'yarn install'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 config.yml
 config.*.yml
 !config.example.yml
+third_party
 
 generated.env.*

--- a/README.md
+++ b/README.md
@@ -6,61 +6,39 @@ This repository contains some helper/wrapper scripts to make working with GN eas
 
 ### macOS / Linux
 
-```bash
-git clone https://github.com/MarshallOfSound/electron-gn-scripts.git
-cd electron-gn-scripts
-yarn
-# You could also use `npm install` here
-# You should probably add this to your path in your `.zshrc` or `.bashrc`
-export PATH="$PATH:$(pwd)/nix"
+```sh
+$ git clone https://github.com/MarshallOfSound/electron-gn-scripts.git
+$ cd electron-gn-scripts
+$ export PATH="$PATH:/path/to/electron-gn-scripts/nix"
+# ^ You should probably add this to your `~/.profile`
 ```
 
 ### Windows
 
 ```batch
-git clone https://github.com/MarshallOfSound/electron-gn-scripts.git
-cd electron-gn-scripts
-set PATH="%PATH%;"
+PS> git clone https://github.com/MarshallOfSound/electron-gn-scripts.git
+PS> cd electron-gn-scripts\win
+PS> set PATH="%PATH%;%CD%"
 ```
 
-## Setup
+On Windows, you'll also need to install [`depot_tools`](https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up) as outlined in the [GN Build Instructions](https://github.com/electron/electron/blob/master/docs/development/build-instructions-gn.md) and summarized here:
 
-This toolset does not yet have the ability to initialize an Electron GN setup from scratch so you'll have to
-do the initial work.  These steps are outlined in the [GN Build Instructions](https://github.com/electron/electron/blob/master/docs/development/build-instructions-gn.md) and summarized below.
-
-## Install Depot Tools
-
-You'll need to install [`depot_tools`](https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up)  to your system.
-
-**On macOS:**
-
-```sh
-# Ensure you're in your home directory
-cd ~
-git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-```
-
-Add `depot_tools` to the end of your PATH (you will probably want to put this in your `~/.bashrc` or `~/.zshrc`).
-
-**On Windows:**
-
-1) Download the `depot_tools` [bundle](https://storage.googleapis.com/chrome-infra/depot_tools.zip) and extract it to `C:\workspace\depot_tools`
-2) Add `depot_tools` to the start of your `PATH` (must be ahead of any installs of Python)
-3) From a cmd.exe shell, run the command `gclient` (with **no** arguments)
+ 1. Download the `depot_tools` [bundle](https://storage.googleapis.com/chrome-infra/depot_tools.zip) and extract it to `C:\workspace\depot_tools`
+ 2. Add `depot_tools` to the start of your `PATH` (must be ahead of any installs of Python)
+ 3. From a cmd.exe shell, run the command `gclient` (with **no** arguments)
 
 ## Initial Electron Setup
 
-After you've set up `depot_tools`, you'll only need to use the `e` command to perform initial setup.
+Getting and building Electron only requires the `e` command:
 
-```bash
-cd /path/to/your/developer/folder
+```sh
+$ cd /path/to/your/developer/folder
 # This will create a new "electron" folder in the current directory
 # It will set up a new evm config
 # Sync down all the required code and bootstrap the output directory
-e fetch
+$ e fetch
+$ e build
 ```
-
-Following this, you just have to use `e build` and friends to actually build your newly cloned Electron setup.
 
 ## Usage
 
@@ -81,13 +59,13 @@ Some possible extra arguments include:
 Basic Usage:
 
 ```sh
-e sync
+$ e sync
 ```
 
 Example Usage with extra arguments:
 
 ```sh
-e sync --ignore_locks
+$ e sync --ignore_locks
 ```
 
 ### `e bootstrap`
@@ -97,7 +75,7 @@ e sync --ignore_locks
 This command is the equivalent of `gn gen`: it generates required output directories and ninja configurations.
 
 ```sh
-e bootstrap
+$ e bootstrap
 ```
 
 ### `e build`
@@ -119,42 +97,41 @@ Example Usage:
 
 ```sh
 # Default - build Electron itself
-e build
+$ e build
 ```
 
 ```sh
 # Build the Electron binary and generates a dist zip file
-e build electron:dist
+$ e build electron:dist
 ```
 
 ```sh
 # Build the mksnapshot binary
-e build mksnapshot
+$ e build mksnapshot
 ```
 
 ```sh
 # Build the chromedriver binary
-e build chromedriver
+$ e build chromedriver
 ```
 
 ```sh
 # Build the node headers .tar.gz file
-e build node:headers
+$ e build node:headers
 ```
 
 ```sh
 # Build the breakpad `dump_syms` binary
-e build breakpad
+$ e build breakpad
 ```
 
 ### `e start`
 
 Starts the generated Electron binary, passes all extra arguments directly through to Electron.  E.g.
 
-```bash
-e start path/to/my/app
-
-e start --version
+```sh
+$ e start --version
+$ e start path/to/my/app
 ```
 
 ### `e test`
@@ -169,22 +146,22 @@ Possible Extra Arguments:
 Basic Usage:
 
 ```sh
-e test
+$ e test
 ```
 
 Example Extra Arguments:
 
 ```sh
 # Run Main Process tests in CI mode 
-e test --ci --runners=main
+$ e test --ci --runners=main
 ```
 
 ### `e debug`
 
 Initializes [lldb](https://lldb.llvm.org/) (on macOS) or [gdb](https://www.gnu.org/software/gdb/) (on Linux) with the debug target set to your local Electron build.
 
-```bash
-e debug
+```sh
+$ e debug
 
 # You should then see (on macOS, for example):
 # (lldb) target create "/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/MacOS/Electron"
@@ -248,9 +225,9 @@ using `evm`.
 
 If you copy your `config.yml` and name the copy `config.debug.yml` you can switch to that config using
 
-```bash
-evm debug
-e build
+```sh
+$ evm debug
+$ e build
 ```
 
 You can have as many config files as you want and switch to them at any time using `evm $CONFIG_NAME`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ On Windows, you'll also need to install [`depot_tools`](https://commondatastorag
 
 ## Initial Electron Setup
 
-Getting and building Electron only requires the `e` command:
+After the installation steps above, getting and building Electron only
+takes the `e` command:
 
 ```sh
 cd /path/to/your/developer/folder

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ This repository contains some helper/wrapper scripts to make working with GN eas
 ### macOS / Linux
 
 ```sh
-$ git clone https://github.com/MarshallOfSound/electron-gn-scripts.git
-$ export PATH="$PATH:$PWD/electron-gn-scripts/nix"
+git clone https://github.com/MarshallOfSound/electron-gn-scripts.git
+export PATH="$PATH:$PWD/electron-gn-scripts/nix"
 
 # You should probably add this to your `~/.profile` too:
-$ export PATH="$PATH:/path/to/electron-gn-scripts/nix"
+export PATH="$PATH:/path/to/electron-gn-scripts/nix"
 ```
 
 ### Windows
 
 ```batch
-PS> git clone https://github.com/MarshallOfSound/electron-gn-scripts.git
-PS> cd electron-gn-scripts\win
-PS> set PATH="%PATH%;%CD%"
+git clone https://github.com/MarshallOfSound/electron-gn-scripts.git
+cd electron-gn-scripts\win
+set PATH="%PATH%;%CD%"
 ```
 
 On Windows, you'll also need to install [`depot_tools`](https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up) as outlined in the [GN Build Instructions](https://github.com/electron/electron/blob/master/docs/development/build-instructions-gn.md) and summarized here:
@@ -33,12 +33,14 @@ On Windows, you'll also need to install [`depot_tools`](https://commondatastorag
 Getting and building Electron only requires the `e` command:
 
 ```sh
-$ cd /path/to/your/developer/folder
+cd /path/to/your/developer/folder
+
 # This will create a new "electron" folder in the current directory
 # It will set up a new evm config
 # Sync down all the required code and bootstrap the output directory
-$ e fetch
-$ e build
+e fetch
+
+e build
 ```
 
 ## Usage
@@ -60,13 +62,13 @@ Some possible extra arguments include:
 Basic Usage:
 
 ```sh
-$ e sync
+e sync
 ```
 
 Example Usage with extra arguments:
 
 ```sh
-$ e sync --ignore_locks
+e sync --ignore_locks
 ```
 
 ### `e bootstrap`
@@ -76,7 +78,7 @@ $ e sync --ignore_locks
 This command is the equivalent of `gn gen`: it generates required output directories and ninja configurations.
 
 ```sh
-$ e bootstrap
+e bootstrap
 ```
 
 ### `e build`
@@ -98,32 +100,32 @@ Example Usage:
 
 ```sh
 # Default - build Electron itself
-$ e build
+e build
 ```
 
 ```sh
 # Build the Electron binary and generates a dist zip file
-$ e build electron:dist
+e build electron:dist
 ```
 
 ```sh
 # Build the mksnapshot binary
-$ e build mksnapshot
+e build mksnapshot
 ```
 
 ```sh
 # Build the chromedriver binary
-$ e build chromedriver
+e build chromedriver
 ```
 
 ```sh
 # Build the node headers .tar.gz file
-$ e build node:headers
+e build node:headers
 ```
 
 ```sh
 # Build the breakpad `dump_syms` binary
-$ e build breakpad
+e build breakpad
 ```
 
 ### `e start`
@@ -131,8 +133,8 @@ $ e build breakpad
 Starts the generated Electron binary, passes all extra arguments directly through to Electron.  E.g.
 
 ```sh
-$ e start --version
-$ e start path/to/my/app
+e start --version
+e start path/to/my/app
 ```
 
 ### `e test`
@@ -147,14 +149,14 @@ Possible Extra Arguments:
 Basic Usage:
 
 ```sh
-$ e test
+e test
 ```
 
 Example Extra Arguments:
 
 ```sh
 # Run Main Process tests in CI mode 
-$ e test --ci --runners=main
+e test --ci --runners=main
 ```
 
 ### `e debug`
@@ -162,7 +164,7 @@ $ e test --ci --runners=main
 Initializes [lldb](https://lldb.llvm.org/) (on macOS) or [gdb](https://www.gnu.org/software/gdb/) (on Linux) with the debug target set to your local Electron build.
 
 ```sh
-$ e debug
+e debug
 
 # You should then see (on macOS, for example):
 # (lldb) target create "/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/MacOS/Electron"
@@ -227,8 +229,8 @@ using `evm`.
 If you copy your `config.yml` and name the copy `config.debug.yml` you can switch to that config using
 
 ```sh
-$ evm debug
-$ e build
+evm debug
+e build
 ```
 
 You can have as many config files as you want and switch to them at any time using `evm $CONFIG_NAME`.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ This repository contains some helper/wrapper scripts to make working with GN eas
 
 ```sh
 $ git clone https://github.com/MarshallOfSound/electron-gn-scripts.git
-$ cd electron-gn-scripts
+$ export PATH="$PATH:$PWD/electron-gn-scripts/nix"
+
+# You should probably add this to your `~/.profile` too:
 $ export PATH="$PATH:/path/to/electron-gn-scripts/nix"
-# ^ You should probably add this to your `~/.profile`
 ```
 
 ### Windows

--- a/nix/commands/__constants.sh
+++ b/nix/commands/__constants.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# colors
+declare -r COLOR_CMD='\033[0;33m' # yellow
+declare -r COLOR_DIR='\033[0;36m' # cyan -- same as chalk use in common/
+declare -r COLOR_ERR='\033[0;31m' # red
+declare -r COLOR_OFF='\033[0m' # no-color
+declare -r COLOR_OK='\033[0;32m' # green
+declare -r COLOR_WARN='\033[1;31m' # light red

--- a/nix/commands/__constants.sh
+++ b/nix/commands/__constants.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# colors
-declare -r COLOR_CMD='\033[0;33m' # yellow
-declare -r COLOR_DIR='\033[0;36m' # cyan -- same as chalk use in common/
-declare -r COLOR_ERR='\033[0;31m' # red
-declare -r COLOR_OFF='\033[0m' # no-color
-declare -r COLOR_OK='\033[0;32m' # green
-declare -r COLOR_WARN='\033[1;31m' # light red

--- a/nix/commands/__tools.sh
+++ b/nix/commands/__tools.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# colors
+# constants
 
 declare -r COLOR_CMD='\033[0;33m' # yellow
 declare -r COLOR_DIR='\033[0;36m' # cyan -- same as chalk use in common/
@@ -9,9 +9,12 @@ declare -r COLOR_OFF='\033[0m' # no-color
 declare -r COLOR_OK='\033[0;32m' # green
 declare -r COLOR_WARN='\033[1;31m' # light red
 
-# functions
+declare __basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+declare -r ELECTRON_GN_SCRIPTS_ROOT="$(git -C "${__basedir}" rev-parse --show-toplevel)"
+declare -r DEPOT_TOOLS_PATH="${ELECTRON_GN_SCRIPTS_ROOT}/third_party/depot_tools"
+unset __basedir
 
-declare -r DEPOT_TOOLS_PATH="$(git -C "$(dirname "$(readlink -f "$0")")" rev-parse --show-toplevel)/third_party/depot_tools"
+# functions
 
 ensure_depot_tools() {
   # if it's missing, install it
@@ -35,8 +38,7 @@ ensure_depot_tools() {
 
 ensure_node_modules() {
   # if it's missing, install it
-  local -r top="$(git -C "$(dirname "$(readlink -f "$0")")" rev-parse --show-toplevel)"
-  if [[ ! -d "$top/node_modules" ]]; then
+  if [[ ! -d "${ELECTRON_GN_SCRIPTS_ROOT}/node_modules" ]]; then
     echo -e "\n\nRunning '${COLOR_CMD}yarn install${COLOR_OFF}' in '${COLOR_DIR}$top${COLOR_OFF}'"
     npx yarn --cwd "$top" install --frozen-lockfile
     if [[ $? -ne 0 ]]; then

--- a/nix/commands/__tools.sh
+++ b/nix/commands/__tools.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# colors
+
+declare -r COLOR_CMD='\033[0;33m' # yellow
+declare -r COLOR_DIR='\033[0;36m' # cyan -- same as chalk use in common/
+declare -r COLOR_ERR='\033[0;31m' # red
+declare -r COLOR_OFF='\033[0m' # no-color
+declare -r COLOR_OK='\033[0;32m' # green
+declare -r COLOR_WARN='\033[1;31m' # light red
+
+# functions
+
+declare -r DEPOT_TOOLS_PATH="$(git -C "$(dirname "$(readlink -f "$0")")" rev-parse --show-toplevel)/third_party/depot_tools"
+
+ensure_depot_tools() {
+  # if it's missing, install it
+  if [[ ! -d "$DEPOT_TOOLS_PATH" ]]; then
+    echo -e "\n\nCloning ${COLOR_CMD}depot_tools${COLOR_OFF} into '${COLOR_DIR}$DEPOT_TOOLS_PATH${COLOR_OFF}'"
+    git clone -q 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' "$DEPOT_TOOLS_PATH"
+    if [[ $? -ne 0 ]]; then
+      exit $?
+    fi
+  fi
+
+  # if it's been awhile, update it
+  local -r mtime_age_days="$(perl -e 'print int -M $ARGV[0]' "$DEPOT_TOOLS_PATH")"
+  local -r update_interval_days=14
+  if (( $mtime_age_days > $update_interval_days )); then
+    echo -e "\n\nUpdating ${COLOR_CMD}depot_tools${COLOR_OFF} into '${COLOR_DIR}$DEPOT_TOOLS_PATH${COLOR_OFF}'"
+    git -C "${DEPOT_TOOLS_PATH}" pull origin master
+    touch "${DEPOT_TOOLS_PATH}"
+  fi
+}
+
+ensure_node_modules() {
+  # if it's missing, install it
+  local -r top="$(git -C "$(dirname "$(readlink -f "$0")")" rev-parse --show-toplevel)"
+  if [[ ! -d "$top/node_modules" ]]; then
+    echo -e "\n\nRunning '${COLOR_CMD}yarn install${COLOR_OFF}' in '${COLOR_DIR}$top${COLOR_OFF}'"
+    yarn --cwd "$top" install
+    if [[ $? -ne 0 ]]; then
+      exit $?
+    fi
+  fi
+}

--- a/nix/commands/__tools.sh
+++ b/nix/commands/__tools.sh
@@ -38,7 +38,7 @@ ensure_node_modules() {
   local -r top="$(git -C "$(dirname "$(readlink -f "$0")")" rev-parse --show-toplevel)"
   if [[ ! -d "$top/node_modules" ]]; then
     echo -e "\n\nRunning '${COLOR_CMD}yarn install${COLOR_OFF}' in '${COLOR_DIR}$top${COLOR_OFF}'"
-    yarn --cwd "$top" install
+    npx yarn --cwd "$top" install --frozen-lockfile
     if [[ $? -ne 0 ]]; then
       exit $?
     fi

--- a/nix/commands/__tools.sh
+++ b/nix/commands/__tools.sh
@@ -39,8 +39,8 @@ ensure_depot_tools() {
 ensure_node_modules() {
   # if it's missing, install it
   if [[ ! -d "${ELECTRON_GN_SCRIPTS_ROOT}/node_modules" ]]; then
-    echo -e "\n\nRunning '${COLOR_CMD}yarn install${COLOR_OFF}' in '${COLOR_DIR}$top${COLOR_OFF}'"
-    npx yarn --cwd "$top" install --frozen-lockfile
+    echo -e "\n\nRunning '${COLOR_CMD}yarn install${COLOR_OFF}' in '${COLOR_DIR}${ELECTRON_GN_SCRIPTS_ROOT}${COLOR_OFF}'"
+    npx yarn --cwd "${ELECTRON_GN_SCRIPTS_ROOT}" install --frozen-lockfile
     if [[ $? -ne 0 ]]; then
       exit $?
     fi

--- a/nix/commands/bootstrap.sh
+++ b/nix/commands/bootstrap.sh
@@ -3,11 +3,11 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-source "$basedir/__constants.sh"
 source "$basedir/__load-config.sh"
-
+source "$basedir/__tools.sh"
+ensure_depot_tools
+ 
 readonly src_path="$ELECTRON_GN_ROOT/src"
 echo -e "Running '${COLOR_CMD}gn gen${COLOR_OFF}' in '${COLOR_DIR}$src_path${COLOR_OFF}'"
 cd "$src_path"
-
-gn gen "out/$ELECTRON_OUT_DIR" --args="import(\"//electron/build/args/$GN_IMPORT_NAME.gn\") cc_wrapper=\"$ELECTRON_GN_ROOT/src/electron/external_binaries/sccache\" $EXTRA_GN_ARGS"
+PATH="$DEPOT_TOOLS_PATH:$PATH" gn gen "out/$ELECTRON_OUT_DIR" --args="import(\"//electron/build/args/$GN_IMPORT_NAME.gn\") cc_wrapper=\"$ELECTRON_GN_ROOT/src/electron/external_binaries/sccache\" $EXTRA_GN_ARGS"

--- a/nix/commands/bootstrap.sh
+++ b/nix/commands/bootstrap.sh
@@ -3,10 +3,11 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-
+source "$basedir/__constants.sh"
 source "$basedir/__load-config.sh"
 
-echo Running \"gn gen\" in \""$ELECTRON_GN_ROOT/src"\"
-cd "$ELECTRON_GN_ROOT/src"
+readonly src_path="$ELECTRON_GN_ROOT/src"
+echo -e "Running '${COLOR_CMD}gn gen${COLOR_OFF}' in '${COLOR_DIR}$src_path${COLOR_OFF}'"
+cd "$src_path"
 
 gn gen "out/$ELECTRON_OUT_DIR" --args="import(\"//electron/build/args/$GN_IMPORT_NAME.gn\") cc_wrapper=\"$ELECTRON_GN_ROOT/src/electron/external_binaries/sccache\" $EXTRA_GN_ARGS"

--- a/nix/commands/build.sh
+++ b/nix/commands/build.sh
@@ -3,8 +3,8 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-source "$basedir/__constants.sh"
 source "$basedir/__load-config.sh"
+source "$basedir/__tools.sh"
 
 cd "$ELECTRON_GN_ROOT/src"
 
@@ -19,8 +19,9 @@ ensure_sccache () {
 
 build_target() {
   ensure_sccache
+  ensure_depot_tools
   echo -e "Running '${COLOR_CMD}ninja${COLOR_OFF}' in '${COLOR_DIR}$ELECTRON_GN_ROOT/src${COLOR_OFF}' with target '$1'"
-  ninja -C "out/$ELECTRON_OUT_DIR" "$1"
+  PATH="$DEPOT_TOOLS_PATH:$PATH" ninja -C "out/$ELECTRON_OUT_DIR" "$1"
 }
 
 bad_build_target() {

--- a/nix/commands/build.sh
+++ b/nix/commands/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-
+source "$basedir/__constants.sh"
 source "$basedir/__load-config.sh"
 
 cd "$ELECTRON_GN_ROOT/src"
@@ -13,18 +13,18 @@ ensure_sccache () {
   $SCCACHE_PATH --stop-server &> /dev/null || true
   until $SCCACHE_PATH --start-server
   do
-    echo Failed to start sccache, trying again...
+    echo -e "${COLOR_WARN}Failed to start sccache, trying again...${COLOR_OFF}"
   done
 }
 
 build_target() {
   ensure_sccache
-  echo Running \"ninja\" in \""$ELECTRON_GN_ROOT/src"\" with target \""$1"\"
+  echo -e "Running '${COLOR_CMD}ninja${COLOR_OFF}' in '${COLOR_DIR}$ELECTRON_GN_ROOT/src${COLOR_OFF}' with target '$1'"
   ninja -C "out/$ELECTRON_OUT_DIR" "$1"
 }
 
 bad_build_target() {
-  echo "Unknown build target \"$1\", please check the README for possible targets"
+  echo -e "${COLOR_ERR}Unknown build target \"$1\", please check the README for possible targets${COLOR_OFF}"
   exit 1
 }
 

--- a/nix/commands/fetch.sh
+++ b/nix/commands/fetch.sh
@@ -3,10 +3,12 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-source "$basedir/__constants.sh"
+source "$basedir/__load-config.sh"
+source "$basedir/__tools.sh"
+ensure_depot_tools
+ensure_node_modules
 
 readonly target_dir=$(pwd)/electron
-
 if [ -d "electron" ]; then
   echo -e "${COLOR_ERR}'$target_dir' already exists. Please remove it or cd to a different directory.${COLOR_OFF}"
   exit 1
@@ -21,7 +23,7 @@ cd "$target_dir"
 echo
 echo
 echo -e "Running '${COLOR_CMD}gclient config${COLOR_OFF}' in '${COLOR_DIR}$target_dir${COLOR_OFF}'"
-gclient config --name 'src/electron' --unmanaged 'https://github.com/electron/electron'
+PATH="$DEPOT_TOOLS_PATH:$PATH" gclient config --name 'src/electron' --unmanaged 'https://github.com/electron/electron'
 
 new_config=$(node "$basedir/../../common/new-config-for-fetch.js" "$target_dir")
 

--- a/nix/commands/fetch.sh
+++ b/nix/commands/fetch.sh
@@ -3,42 +3,45 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source "$basedir/__constants.sh"
 
-target_dir=$(pwd)/electron
+readonly target_dir=$(pwd)/electron
 
 if [ -d "electron" ]; then
-  echo "'$target_dir' already exists. Please remove it or cd to a different directory."
+  echo -e "${COLOR_ERR}'$target_dir' already exists. Please remove it or cd to a different directory.${COLOR_OFF}"
   exit 1
 fi
 
-echo "Creating $target_dir for Electron checkout"
+echo
+echo
+echo -e "Creating '${COLOR_DIR}$target_dir${COLOR_OFF}' for Electron checkout"
 mkdir -p "$target_dir"
 cd "$target_dir"
 
 echo
 echo
-echo "Running 'gclient config'"
+echo -e "Running '${COLOR_CMD}gclient config${COLOR_OFF}' in '${COLOR_DIR}$target_dir${COLOR_OFF}'"
 gclient config --name 'src/electron' --unmanaged 'https://github.com/electron/electron'
 
 new_config=$(node "$basedir/../../common/new-config-for-fetch.js" "$target_dir")
 
 echo
 echo
-echo "Running 'evm $new_config'"
+echo -e "Running '${COLOR_CMD}evm $new_config${COLOR_OFF}'"
 evm "$new_config"
 
 source "$basedir/__load-config.sh"
 
 echo
 echo
-echo "Running 'e sync -vv'"
+echo -e "Running '${COLOR_CMD}e sync -vv${COLOR_OFF}'"
 e sync -vv
 
 echo
 echo
-echo "Running 'e bootstrap'"
+echo -e "Running '${COLOR_CMD}e bootstrap${COLOR_OFF}'"
 e bootstrap
 
 echo
 echo
-echo "You should be all set! Try running 'e build' to build a local version of Electron now."
+echo -e "You should be all set! Try running '${COLOR_CMD}e build${COLOR_OFF}' to build Electron now."

--- a/nix/commands/fetch.sh
+++ b/nix/commands/fetch.sh
@@ -3,7 +3,6 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-source "$basedir/__load-config.sh"
 source "$basedir/__tools.sh"
 ensure_depot_tools
 ensure_node_modules

--- a/nix/commands/pr.sh
+++ b/nix/commands/pr.sh
@@ -4,6 +4,8 @@ set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$basedir/__load-config.sh"
+source "$basedir/__tools.sh"
+ensure_node_modules
 
 cd "$ELECTRON_GN_ROOT/src/electron"
 

--- a/nix/commands/sync.sh
+++ b/nix/commands/sync.sh
@@ -3,14 +3,15 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-source "$basedir/__constants.sh"
 source "$basedir/__load-config.sh"
+source "$basedir/__tools.sh"
+ensure_depot_tools
 
 readonly src_path="$ELECTRON_GN_ROOT/src"
 echo -e "Running '${COLOR_CMD}gclient sync${COLOR_OFF}' in '${COLOR_DIR}$src_path${COLOR_OFF}'"
 mkdir -p "$src_path"
 cd "$src_path"
-gclient sync --with_branch_heads --with_tags "$@"
+PATH="$DEPOT_TOOLS_PATH:$PATH" gclient sync --with_branch_heads --with_tags "$@"
 
 echo -e "${COLOR_OK}Updating Git Remotes${COLOR_OFF}"
 

--- a/nix/commands/sync.sh
+++ b/nix/commands/sync.sh
@@ -3,22 +3,23 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source "$basedir/__constants.sh"
 source "$basedir/__load-config.sh"
 
-echo "Running '$(which gclient) sync' in '$ELECTRON_GN_ROOT/src'"
-mkdir -p "$ELECTRON_GN_ROOT/src"
-cd "$ELECTRON_GN_ROOT/src"
-
+readonly src_path="$ELECTRON_GN_ROOT/src"
+echo -e "Running '${COLOR_CMD}gclient sync${COLOR_OFF}' in '${COLOR_DIR}$src_path${COLOR_OFF}'"
+mkdir -p "$src_path"
+cd "$src_path"
 gclient sync --with_branch_heads --with_tags "$@"
 
-echo Updating Git Remotes
+echo -e "${COLOR_OK}Updating Git Remotes${COLOR_OFF}"
 
-cd "$ELECTRON_GN_ROOT/src/electron"
+cd "$src_path/electron"
 git remote set-url origin "$ELECTRON_GIT_ORIGIN"
 git remote set-url origin --push "$ELECTRON_GIT_ORIGIN"
 
-cd "$ELECTRON_GN_ROOT/src/third_party/electron_node"
+cd "$src_path/third_party/electron_node"
 git remote set-url origin "$NODE_GIT_ORIGIN"
 git remote set-url origin --push "$NODE_GIT_ORIGIN"
 
-echo Done Syncing
+echo -e "${COLOR_OK}Done Syncing${COLOR_OFF}"

--- a/nix/commands/test.sh
+++ b/nix/commands/test.sh
@@ -4,6 +4,8 @@ set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$basedir/__load-config.sh"
+source "$basedir/__tools.sh"
+ensure_node_modules
 
 # to run the tests, you'll first need to build the test modules
 # against the same version of Node.js that was built as part of

--- a/nix/commands/testnode.sh
+++ b/nix/commands/testnode.sh
@@ -4,6 +4,8 @@ set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$basedir/__load-config.sh"
+source "$basedir/__tools.sh"
+ensure_node_modules
 
 cd "$ELECTRON_GN_ROOT/src/electron"
 

--- a/nix/evm
+++ b/nix/evm
@@ -3,7 +3,7 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-source "$basedir/commands/__constants.sh"
+source "$basedir/commands/__tools.sh"
 
 ensure_node_modules
 

--- a/nix/evm
+++ b/nix/evm
@@ -3,5 +3,8 @@
 set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source "$basedir/commands/__constants.sh"
+
+ensure_node_modules
 
 node "$basedir/../common/switch.js" "$1"


### PR DESCRIPTION
When invoking depot tools commands used by our scripts (gn, gclient, ninja), ensure that the depot_tools repo is cloned into `electron-gn-scripts/third_party/depot_tools` and temporarily prepend that directory into the path. Also, give `depot_tools` a pull every fortnight to stay up-to-date.

Likewise, ensure that `yarn install` has been called before invoking node.