### PR TITLE
fix: realpath is linux-only

### DIFF
--- a/nix/commands/__load-config.sh
+++ b/nix/commands/__load-config.sh
@@ -2,7 +2,7 @@
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-config_path=$(realpath "$basedir/../../generated.env.sh")
+config_path="$basedir/../../generated.env.sh"
 
 if [[ ! -f "$config_path" ]]; then
   echo "Configuration '$config_path' not found. (Do you need to run 'evm' or 'e fetch'?)"


### PR DESCRIPTION
`realpath` is a [linux-only](http://man7.org/linux/man-pages/man3/realpath.3.html) command and so errors on mac:

```sh
src on git:0fa60ec54270 ❯ e export-patches                                     8:46AM
/Users/codebytere/electron-gn-scripts/nix/commands/__load-config.sh: line 5: realpath: command not found
```

cc @ckerr 